### PR TITLE
so-c#6 electron-builder の非互換見落とし

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "license:generate": "node build/generateLicenses.js",
     "license:merge": "node build/mergeLicenses.js"
   },
-  "main": "background.js",
   "dependencies": {
     "@gtm-support/vue-gtm": "1.2.3",
     "@quasar/extras": "1.10.10",


### PR DESCRIPTION
close https://github.com/so-c/voicevox/issues/6

[Releases · nklayman/vue-cli-plugin-electron-builder](https://github.com/nklayman/vue-cli-plugin-electron-builder/releases)の

Remove the main field from your package.json

見落とし。serveでは動くがbuildでErrorが出るようになる